### PR TITLE
Fix: updated front-matter metadata ignore regex to avoid matching tables & horizontal lines

### DIFF
--- a/src/ts/objects/IgnoreRange.ts
+++ b/src/ts/objects/IgnoreRange.ts
@@ -108,7 +108,7 @@ class IgnoreRangeBuilder {
 	}
 
 	public addMdMetadata(): IgnoreRangeBuilder {
-		const regex = /---(.|\n)*---/g;
+		const regex = /^---[\s\S]*?---/;
 		return this.addIgnoreRangesWithRegex(regex);
 	}
 }


### PR DESCRIPTION
## Summary
- This should fix a bug where note links are not detected between the first and last table of .md files or between horizontal lines created using hyphens.
- Constrain the front-matter metadata ignore regex so it only matches the leading metadata block.
- Use a non-greedy wildcard to stop at the first closing `---`, preventing the expression from swallowing table separators and horizontal lines later in the document.
 
## Rationale
Markdown files that begin with front matter delimiters (`---`) should have that metadata skipped when generating ignore ranges, but the previous regex used a greedy `/(.\|\n)*/g` pattern. When a document contained tables (which also use `---` in their separator rows) or horizontal lines using hyphens ('---'), the greedy match consumed the entire section between the first and last table/horizontal line, so note links were not detected there. Anchoring the pattern to the start of the file with `^` (obsidian only recognizes front matter at the top of the document anyways) and switching to a non-greedy wildcard (`[\s\S]*?`) ensures only the initial metadata block is ignored while the rest of the document remains searchable.
 
## Issue References
The repository currently tracks the table parsing bug in multiple places. I am listing them here so maintainers can close them later.
 
Closes AlexW00/obsidian-note-linker#63 [Anything below a table is not linked]
~~Closes AlexW00/obsidian-note-linker#13 [created link will break markdown table]~~ (appears to not be fixed. the issue occurs in obsidian by default when any link with an alias `[[Note|NoteAlias]]` appears in a table. obsidian devs claim it's intended and the workaround is to escape the pipe `[[Note\|NoteAlias]]`)
   
## Testing 
I was able to successfully build and test locally in obsidian. The plugin loads and works as expected, and now correctly detects links in text between the first table and last table of a .md file while still ignoring the front-matter at the top of the file. Quick ad-hoc testing showed no side-effects from this change
 
### Regression Risk Considerations
The original ignore logic was introduced in [1.1.1](https://github.com/AlexW00/obsidian-note-linker/releases/tag/1.1.1) with the greedy `/---(.\|\n)*---/g` pattern. The commit landed directly on `main` with the message "added: ignore md metadata" and has no associated pull request or discussion that would justify matching past the initial metadata block. Thus, I assume the behavior most likely came from an overly-broad regex example rather than a deliberate requirement. 
 


