### PR TITLE
Add ignore-range handling for embedded links

### DIFF
--- a/src/ts/objects/IgnoreRange.ts
+++ b/src/ts/objects/IgnoreRange.ts
@@ -70,6 +70,11 @@ class IgnoreRangeBuilder {
 		return this.addCacheItem(this._cache.headings);
 	}
 
+	// adds embedded links to the ignore ranges (e.g. ![[Note]])
+	public addEmbeds(): IgnoreRangeBuilder {
+		return this.addCacheItem(this._cache.embeds);
+	}
+
 	// adds code blocks to the ignore ranges
 	// code blocks are of the form ```code```
 	public addCodeSections(): IgnoreRangeBuilder {
@@ -131,6 +136,7 @@ export default class IgnoreRange extends Range {
 			// from cache
 			.addInternalLinks()
 			.addHeadings()
+			.addEmbeds()
 			.addCodeSections()
 			// from regex
 			.addMdMetadata()


### PR DESCRIPTION
## Summary 
`IgnoreRangeBuilder` now includes embedded links `![[...]]` when constructing ignore ranges, using `cache.embeds`. This prevents the linker from modifying content inside Obsidian embed syntax.

## Rationale
Currently, embeds like `![[Javascript]]` are scanned as regular text, causing the linker to inject new wikilinks inside the embed and produce invalid output and breaking the embed in the process: `![[[[Javascript]]]]`.

[Embeds](https://help.obsidian.md/embeds) are already links by design and should be treated as atomic – the plugin should not attempt to relink their contents.
 
## Issue References
The repository currently tracks the bug in multiple places. I am listing them here so maintainers can close them later.
Closes AlexW00/obsidian-note-linker#67 [Linking breaks embedding of Notes]
Closes AlexW00/obsidian-note-linker#14 [generate invalid link within Embed notes]
Closes AlexW00/obsidian-note-linker#48 [disable linking if text is inside a link] (this was already addressed with .addHtml(), .addMdLinks(), .addWebLinks())
 
## Potential regressions or concerns
The additional ignore pass blanked out embedded links before regex-based range detection. That should prevent link handling inside embeds but also strips any alt/display text from the content used downstream; if users rely on transcluded text to surface link suggestions, the new ignore step will prevent that detection.
   
## Testing 
I was able to successfully build and test locally in obsidian. The plugin loads and works as expected, and now correctly ignores embeds during the linking process. Quick ad-hoc testing showed no side-effects from this change.