### PR TITLE
Fix overlapping title/alias matching and fix alias pre-selection in UI

### DIFF
--- a/src/rs/matching/link_finder.rs
+++ b/src/rs/matching/link_finder.rs
@@ -104,14 +104,23 @@ fn find_link_matches(target_note: &Note, note_to_check: &mut Note) -> Option<Vec
 /// If the link match is already in the list, it is merged with the existing link match.
 /// If the link match is not in the list, it is added to the list.
 fn merge_link_match_into_link_matches(mut merged_link_matches: Vec<LinkMatch>, link_match: LinkMatch) -> Vec<LinkMatch> {
+    // Find an existing match that starts at the same character position
     let index = merged_link_matches.iter()
-        .position(|m: &LinkMatch| m.position().is_equal_to(&link_match.position()));
+        .position(|m: &LinkMatch| m.position().start() == link_match.position().start());
 
     if let Some(index) = index {
-        // merge it into the existing match, if the position is the same
-        merged_link_matches[index].merge_link_target_candidates(link_match);
+        // For same-start matches, prefer the one that covers more characters
+        if link_match.position().end() > merged_link_matches[index].position().end() {
+            // New match is longer: make it the primary span and pull in old candidates
+            let mut new_link_match = link_match;
+            new_link_match.merge_link_target_candidates(merged_link_matches[index].clone());
+            merged_link_matches[index] = new_link_match;
+        } else {
+            // Existing match is longer or equal: keep its span, just add new candidates
+            merged_link_matches[index].merge_link_target_candidates(link_match);
+        }
     } else {
-        // otherwise push a new match
+        // No same-start match yet: add as a new entry
         merged_link_matches.push(link_match);
     }
     merged_link_matches

--- a/src/rs/matching/link_finder.rs
+++ b/src/rs/matching/link_finder.rs
@@ -77,6 +77,9 @@ fn build_link_finder(target_note: &Note) -> LinkFinder {
     let escaped_title = escape(&*target_note.title()).to_string();
     escaped_search_strings.push(escaped_title);
 
+    // Sort by length (desc) to prioritize longer matches when alternatives overlap
+    escaped_search_strings.sort_by(|a, b| b.len().cmp(&a.len()));
+    
     let regex_string = concat_as_regex_string(&escaped_search_strings);
     //log(&format!("Regex string: {}", regex_string));
     

--- a/src/rs/matching/link_match.rs
+++ b/src/rs/matching/link_match.rs
@@ -52,7 +52,7 @@ impl LinkMatch {
           target_note.title(),
           target_note.path(),
           target_note.aliases_vec(),
-            regex_match.capture_index
+            &regex_match.matched_text
         )];
         Self::new(
             regex_match.position.clone(),

--- a/src/rs/matching/link_target_candidate.rs
+++ b/src/rs/matching/link_target_candidate.rs
@@ -38,19 +38,15 @@ impl LinkTargetCandidate {
 
 impl LinkTargetCandidate {
     pub fn new(title: String, path: String, aliases: &[String], matched_text: &str) -> Self {
-        let mut preferred_set = false;
-        let matched_lower = matched_text.to_lowercase();
+        let mut preferred_set = title == matched_text;
 
         let mut _replacement_candidates: Vec<PreferrableItem> = vec![];
-        let replacement_candidate_title = PreferrableItem::new(
-            title.clone(),
-            title.to_lowercase() == matched_lower,
-        );
-        preferred_set = replacement_candidate_title.is_preferred;
+        let replacement_candidate_title =
+            PreferrableItem::new(title.clone(), preferred_set);
         _replacement_candidates.push(replacement_candidate_title);
 
         aliases.iter().for_each(|alias| {
-            let is_preferred = !preferred_set && alias.to_lowercase() == matched_lower;
+            let is_preferred = !preferred_set && alias == matched_text;
             if is_preferred {
                 preferred_set = true;
             }

--- a/src/rs/matching/link_target_candidate.rs
+++ b/src/rs/matching/link_target_candidate.rs
@@ -37,19 +37,33 @@ impl LinkTargetCandidate {
 }
 
 impl LinkTargetCandidate {
-    pub fn new(title: String, path: String, aliases: &[String], selected_index: usize) -> Self {
+    pub fn new(title: String, path: String, aliases: &[String], matched_text: &str) -> Self {
+        let mut preferred_set = false;
+        let matched_lower = matched_text.to_lowercase();
+
         let mut _replacement_candidates: Vec<PreferrableItem> = vec![];
-        let replacement_candidate_title = PreferrableItem::new(title.clone(), true);
+        let replacement_candidate_title = PreferrableItem::new(
+            title.clone(),
+            title.to_lowercase() == matched_lower,
+        );
+        preferred_set = replacement_candidate_title.is_preferred;
         _replacement_candidates.push(replacement_candidate_title);
 
-        aliases.iter().enumerate().for_each(|(index, alias)| {
-            let replacement_candidate_alias = PreferrableItem::new(
-                alias.clone(),
-                // add one because the index starts with the title at 0
-                true,
-            );
+        aliases.iter().for_each(|alias| {
+            let is_preferred = !preferred_set && alias.to_lowercase() == matched_lower;
+            if is_preferred {
+                preferred_set = true;
+            }
+
+            let replacement_candidate_alias = PreferrableItem::new(alias.clone(), is_preferred);
             _replacement_candidates.push(replacement_candidate_alias);
         });
+
+        if !preferred_set {
+            if let Some(first_candidate) = _replacement_candidates.get_mut(0) {
+                first_candidate.is_preferred = true;
+            }
+        }
 
         LinkTargetCandidate {
             title,


### PR DESCRIPTION
## Summary 
This PR improves how the matcher handles overlapping title/alias cases when they occur between word boundaries (e.g., Vue.js vs Vue) and updates link-target pre-selection so the UI defaults to what the user actually wrote whenever possible.

## Rationale
Previously, the matcher always preferred the shorter aliases over the longer ones. Sorting search strings by length (descending) ensures the matcher attempts the most specific/longest candidate first. This also enables different aliases, previously hidden due to premature short-alias matching, to appear as distinct matches.

The UI always pre-selected the first candidate. The updated logic now pre-selects whichever candidate actually matches the text found in the note.
Examples for a note titled Vue.js with alias Vue:
   - Matching `Vue` → `[[Vue.js|Vue]]`
   - Matching `Vue.js` → `[[Vue.js]]`

## Issue References
Closes AlexW00/obsidian-note-linker#65 [Keep a found alias as part of the link]
Closes AlexW00/obsidian-note-linker#66 [Improve pre-selection of alias replacement] 

## Potential Impact
Behavior should now be more correct and predictable, but may feel “different” to users who were accustomed to the previous short-alias-first behavior (which frequently produced unintended matches).

## Testing
The plugin was built and tested locally in Obsidian. The updated matcher behaves as expected and correctly handles overlapping titles and aliases. The “matches found” UI now attempts to pre-select the alias that matches the user’s input when possible. Ad-hoc testing did not reveal any regressions or unintended side effects.

## Footnote
Obsidian treats Markdown as the only note format; all other extensions represent attachments The current normalization logic strips only .md. Supporting additional extensions would require expanding the normalizer, but with Obsidian’s native behavior there isn’t another note suffix to handle.