### PR TITLE
limit suggestions per note support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,9 @@ use crate::rs::note::note_scanned_event::NoteScannedEvent;
 mod rs;
 
 #[wasm_bindgen]
-pub fn find_in_vault(context: JsValue, notes: Array, callback: Function) -> Array {
+pub fn find_in_vault(context: JsValue, notes: Array, callback: Function, 
+                     max_links_per_note: usize, count_existing_links: bool,
+) -> Array {
     let notes: Vec<Note> = notes.iter()
         .filter_map(|note: JsValue| Note::try_from(note).ok())
         .collect();
@@ -22,7 +24,8 @@ pub fn find_in_vault(context: JsValue, notes: Array, callback: Function) -> Arra
     notes.clone().iter_mut().enumerate().for_each(|(index, note)| {
         let _ = call_callback(&callback, &context, build_args(note, index));
 
-        let link_finder_result_option = link_finder::find_links(note, &notes);
+        let link_finder_result_option =
+            link_finder::find_links(note, &notes, max_links_per_note, count_existing_links);
         if let Some(r) = link_finder_result_option {
             res.push(r);
         }
@@ -38,7 +41,9 @@ pub fn find_in_vault(context: JsValue, notes: Array, callback: Function) -> Arra
 
 
 #[wasm_bindgen]
-pub fn find_in_note(context: JsValue, active_note: Note, notes: Array, callback: Function) -> Array {
+pub fn find_in_note(context: JsValue, active_note: Note, notes: Array, callback: Function,
+                    max_links_per_note: usize, count_existing_links: bool,
+) -> Array {
     let notes: Vec<Note> = notes.iter()
         .filter_map(|note: JsValue| Note::try_from(note).ok())
         .collect();
@@ -48,7 +53,8 @@ pub fn find_in_note(context: JsValue, active_note: Note, notes: Array, callback:
 
     let _ = call_callback(&callback, &context, build_args(&note, 0));
 
-    let link_finder_result_option = link_finder::find_links(&mut note, &notes);
+    let link_finder_result_option =
+        link_finder::find_links(&mut note, &notes, max_links_per_note, count_existing_links);
     if let Some(r) = link_finder_result_option {
         res.push(r);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { Plugin } from "obsidian";
+import { App, PluginSettingTab, Setting } from "obsidian";
 import rustPlugin from "../pkg/obisidian_note_linker_bg.wasm";
 import * as wasm from "../pkg";
 import MainModal from "./ts/MainModal";
@@ -8,9 +9,13 @@ import * as Comlink from "comlink";
 // @ts-ignore
 import Wcw from "web-worker:./ts/webWorkers/WasmWorker.ts";
 import { MatchingMode } from "./ts/components/containers/MainComponent";
+import { DEFAULT_SETTINGS, NoteLinkerSettings } from "./settings";
 
 export default class RustPlugin extends Plugin {
+	public settings: NoteLinkerSettings;
+
 	async onload() {
+		await this.loadSettings();
 		// init wasm
 		const buffer = Uint8Array.from(atob(rustPlugin as unknown as string), (c) =>
 			c.charCodeAt(0)
@@ -34,6 +39,8 @@ export default class RustPlugin extends Plugin {
 			name: "Scan Note",
 			callback: () => this.openModal(MatchingMode.Note),
 		});
+
+		this.addSettingTab(new NoteLinkerSettingTab(this.app, this));
 	}
 
 	openModal = async (_matchingModal?: MatchingMode) => {
@@ -51,8 +58,108 @@ export default class RustPlugin extends Plugin {
 			() => {
 				wcw.terminate();
 			},
+			this.settings,
 			_matchingModal
 		);
 		linkMatchSelectionModal.open();
 	};
+
+	async loadSettings() {
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+		if (this.settings.maxLinksPerNote < 1) {
+			this.settings.maxLinksPerNote = DEFAULT_SETTINGS.maxLinksPerNote;
+		}
+	}
+
+	async saveSettings() {
+		await this.saveData(this.settings);
+	}
+}
+
+class NoteLinkerSettingTab extends PluginSettingTab {
+	plugin: RustPlugin;
+
+	constructor(app: App, plugin: RustPlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		const {containerEl} = this;
+		containerEl.empty();
+
+		containerEl.createEl("h2", {text: "Matching"});
+
+		new Setting(containerEl)
+			.setName("Limit matches per note")
+			.setDesc(
+				"Enable to surface only the first N matches for each linked note within a source note."
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.limitMatchesPerNote)
+					.onChange(async (value) => {
+						this.plugin.settings.limitMatchesPerNote = value;
+						await this.plugin.saveSettings();
+						this.display();
+					});
+			});
+
+		if (this.plugin.settings.limitMatchesPerNote) {
+			const maxMatchesSetting = new Setting(containerEl)
+				.setName("Maximum matches per note")
+				.setDesc(
+					"Surface at most N suggestions for the same note when limits are enabled."
+				)
+				.addText((text) => {
+					text.inputEl.type = "number";
+					text.inputEl.min = "1";
+					text
+						.setPlaceholder("3")
+						.setValue(this.plugin.settings.maxLinksPerNote.toString())
+						.onChange(async (value) => {
+							const parsed = Number.parseInt(value, 10);
+							if (Number.isNaN(parsed)) {
+								return;
+							}
+							const clamped = Math.max(1, parsed);
+							this.plugin.settings.maxLinksPerNote = clamped;
+							await this.plugin.saveSettings();
+						});
+					text.inputEl.addEventListener("blur", () => {
+						const parsed = Number.parseInt(text.getValue(), 10);
+						if (Number.isNaN(parsed)) {
+							text.setValue(
+								this.plugin.settings.maxLinksPerNote.toString()
+							);
+							return;
+						}
+						const clamped = Math.max(1, parsed);
+						if (clamped !== parsed) {
+							text.setValue(clamped.toString());
+							this.plugin.settings.maxLinksPerNote = clamped;
+							void this.plugin.saveSettings();
+						}
+					});
+				});
+			maxMatchesSetting.settingEl.addClass("note-linker-subsetting");
+
+			const countExistingSetting = new Setting(containerEl)
+				.setName("Count existing links toward limit")
+				.setDesc(
+					"Treat already linked occurrences as part of the N-match cap so rescans skip them."
+				)
+				.addToggle((toggle) => {
+					toggle
+						.setValue(
+							this.plugin.settings.countExistingLinksTowardLimit
+						)
+						.onChange(async (value) => {
+							this.plugin.settings.countExistingLinksTowardLimit = value;
+							await this.plugin.saveSettings();
+						});
+				});
+			countExistingSetting.settingEl.addClass("note-linker-subsetting");
+		}
+	}
 }

--- a/src/rs/links/mod.rs
+++ b/src/rs/links/mod.rs
@@ -1,3 +1,3 @@
 pub mod normalization;
 
-pub use normalization::normalize_existing_link_key;
+pub use normalization::{normalize_existing_link_key, normalized_link_keys_from};

--- a/src/rs/links/mod.rs
+++ b/src/rs/links/mod.rs
@@ -1,0 +1,3 @@
+pub mod normalization;
+
+pub use normalization::normalize_existing_link_key;

--- a/src/rs/links/normalization.rs
+++ b/src/rs/links/normalization.rs
@@ -1,0 +1,61 @@
+pub fn normalize_existing_link_key(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let anchor_index = trimmed.find('#');
+    let without_anchor = match anchor_index {
+        Some(index) => &trimmed[..index],
+        None => trimmed,
+    };
+
+    let lowered = without_anchor.trim().to_lowercase();
+    if lowered.is_empty() {
+        return None;
+    }
+
+    let normalized = lowered.strip_suffix(".md").unwrap_or(&lowered);
+
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_existing_link_key;
+
+    #[test]
+    fn trims_and_lowercases_values() {
+        assert_eq!(
+            normalize_existing_link_key("  Some Note  "),
+            Some("some note".to_string())
+        );
+    }
+
+    #[test]
+    fn strips_anchor_segments() {
+        assert_eq!(
+            normalize_existing_link_key("Note Title#Heading"),
+            Some("note title".to_string())
+        );
+    }
+
+    #[test]
+    fn removes_md_suffixes() {
+        assert_eq!(
+            normalize_existing_link_key("Folder/Note.md"),
+            Some("folder/note".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_empty_values() {
+        assert_eq!(normalize_existing_link_key(""), None);
+        assert_eq!(normalize_existing_link_key("   "), None);
+        assert_eq!(normalize_existing_link_key("#anchor"), None);
+    }
+}

--- a/src/rs/links/normalization.rs
+++ b/src/rs/links/normalization.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 pub fn normalize_existing_link_key(value: &str) -> Option<String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -24,38 +26,25 @@ pub fn normalize_existing_link_key(value: &str) -> Option<String> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::normalize_existing_link_key;
+pub fn normalized_link_keys_from(title: &str, path: &str, aliases: &[String]) -> HashSet<String> {
+    let mut normalized: HashSet<String> = HashSet::new();
 
-    #[test]
-    fn trims_and_lowercases_values() {
-        assert_eq!(
-            normalize_existing_link_key("  Some Note  "),
-            Some("some note".to_string())
-        );
+    if let Some(value) = normalize_existing_link_key(title) {
+        normalized.insert(value);
+    }
+    if let Some(value) = normalize_existing_link_key(path) {
+        normalized.insert(value);
+    }
+    if path.ends_with(".md") {
+        if let Some(value) = normalize_existing_link_key(&path[..path.len() - 3]) {
+            normalized.insert(value);
+        }
+    }
+    for alias in aliases {
+        if let Some(value) = normalize_existing_link_key(alias) {
+            normalized.insert(value);
+        }
     }
 
-    #[test]
-    fn strips_anchor_segments() {
-        assert_eq!(
-            normalize_existing_link_key("Note Title#Heading"),
-            Some("note title".to_string())
-        );
-    }
-
-    #[test]
-    fn removes_md_suffixes() {
-        assert_eq!(
-            normalize_existing_link_key("Folder/Note.md"),
-            Some("folder/note".to_string())
-        );
-    }
-
-    #[test]
-    fn returns_none_for_empty_values() {
-        assert_eq!(normalize_existing_link_key(""), None);
-        assert_eq!(normalize_existing_link_key("   "), None);
-        assert_eq!(normalize_existing_link_key("#anchor"), None);
-    }
+    normalized
 }

--- a/src/rs/mod.rs
+++ b/src/rs/mod.rs
@@ -1,6 +1,7 @@
-pub mod text;
+pub mod links;
 pub mod matching;
 pub mod note;
+pub mod text;
 pub mod util;
 mod Errors;
 mod replacer;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,20 @@
+export interface NoteLinkerSettings {
+        /**
+         * Enable limiting how many matches are surfaced for a single target note within one source note.
+         */
+        limitMatchesPerNote: boolean;
+        /**
+         * Maximum number of matches to surface for a single target note within one source note when limiting is enabled.
+         */
+        maxLinksPerNote: number;
+        /**
+         * When enabled, already linked instances of a note in the source note count towards the per-note limit.
+         */
+        countExistingLinksTowardLimit: boolean;
+}
+
+export const DEFAULT_SETTINGS: NoteLinkerSettings = {
+        limitMatchesPerNote: false,
+        maxLinksPerNote: 3,
+        countExistingLinksTowardLimit: true,
+};

--- a/src/ts/MainModal.tsx
+++ b/src/ts/MainModal.tsx
@@ -6,22 +6,26 @@ import {
 	MainComponent,
 	MatchingMode,
 } from "./components/containers/MainComponent";
+import { NoteLinkerSettings } from "../settings";
 
 export default class MainModal extends Modal {
 	private root: Root;
 	private readonly wasmComlinkWorkerInstance: any;
 	private readonly _onClose: () => void;
 	private readonly _matchingMode?: MatchingMode;
+	private readonly settings: NoteLinkerSettings;
 
 	constructor(
 		app: App,
 		instance: any,
 		_onClose: () => void,
+		settings: NoteLinkerSettings,
 		_matchingMode?: MatchingMode
 	) {
 		super(app);
 		this.wasmComlinkWorkerInstance = instance;
 		this._onClose = _onClose;
+		this.settings = settings;
 		this._matchingMode = _matchingMode ?? MatchingMode.None;
 	}
 
@@ -33,7 +37,9 @@ export default class MainModal extends Modal {
 				<WasmWorkerInstanceContext.Provider
 					value={this.wasmComlinkWorkerInstance}
 				>
-					<MainComponent _matchingMode={this._matchingMode} />
+					<MainComponent _matchingMode={this._matchingMode}
+						settings={this.settings}
+					/>
 				</WasmWorkerInstanceContext.Provider>
 			</AppContext.Provider>
 		);

--- a/src/ts/components/containers/MainComponent.tsx
+++ b/src/ts/components/containers/MainComponent.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { StartComponent } from "./StartComponent";
 import { MatcherComponent } from "./MatcherComponent";
+import { NoteLinkerSettings } from "../../../settings";
 
 export enum MatchingMode {
 	None,
@@ -10,9 +11,10 @@ export enum MatchingMode {
 
 export interface MainComponentProps {
 	_matchingMode: MatchingMode;
+	settings: NoteLinkerSettings;
 }
 
-export const MainComponent = ({ _matchingMode }: MainComponentProps) => {
+export const MainComponent = ({ _matchingMode, settings }: MainComponentProps) => {
 	const [matchingMode, setMatchingMode] = useState<MatchingMode>(_matchingMode);
 
 	const onClickScan = (type: MatchingMode) => {
@@ -21,5 +23,5 @@ export const MainComponent = ({ _matchingMode }: MainComponentProps) => {
 
 	if (matchingMode == MatchingMode.None)
 		return <StartComponent onClickScan={onClickScan} />;
-	else return <MatcherComponent matchingMode={matchingMode} />;
+	else return <MatcherComponent matchingMode={matchingMode} settings={settings} />;
 };

--- a/src/ts/components/containers/MatcherComponent.tsx
+++ b/src/ts/components/containers/MatcherComponent.tsx
@@ -15,7 +15,10 @@ import { useApp, useWasmWorkerInstance } from "../../hooks";
 import { MatchingMode } from "./MainComponent";
 import { NoteLinkerSettings } from "../../../settings";
 
-const WASM_UNLIMITED_LINK_LIMIT = 4294967295;
+// Use a sentinel that maps to Rust's `usize::MAX` so the matcher can treat it as an
+// unlimited cap across architectures. The value overflows to `u32::MAX` on the
+// wasm target while remaining well above any practical limit on native builds.
+const UNLIMITED_LINK_LIMIT = Number.MAX_SAFE_INTEGER;
 
 enum MatchingState {
 	Initializing,
@@ -92,7 +95,7 @@ export const MatcherComponent = ({ matchingMode, settings }: MatcherComponentPro
         const limitEnabled = settings.limitMatchesPerNote;
         const maxLinksPerNote = limitEnabled
                 ? Math.max(1, Math.floor(settings.maxLinksPerNote))
-                : WASM_UNLIMITED_LINK_LIMIT;
+                : UNLIMITED_LINK_LIMIT;
         const countExistingLinks =
                 limitEnabled && settings.countExistingLinksTowardLimit;
 

--- a/src/ts/objects/IgnoreRange.ts
+++ b/src/ts/objects/IgnoreRange.ts
@@ -14,6 +14,8 @@ const normalizeLinkTarget = (link?: string | null): string | null => {
                 return null;
         }
 
+		console.log("Debug:", link); //todo: remove
+
         const trimmed = link.trim();
         if (!trimmed.length) {
                 return null;

--- a/src/ts/objects/IgnoreRange.ts
+++ b/src/ts/objects/IgnoreRange.ts
@@ -7,11 +7,39 @@ import {
 } from "obsidian";
 import { Range } from "../../../pkg";
 
+export type ExistingLinkCountMap = Record<string, number>;
+
+const normalizeLinkTarget = (link?: string | null): string | null => {
+        if (!link) {
+                return null;
+        }
+
+        const trimmed = link.trim();
+        if (!trimmed.length) {
+                return null;
+        }
+
+        const anchorIndex = trimmed.indexOf("#");
+        const withoutAnchor = anchorIndex === -1 ? trimmed : trimmed.slice(0, anchorIndex);
+        const base = withoutAnchor.trim();
+        if (!base.length) {
+                return null;
+        }
+
+        const lowerCased = base.toLowerCase();
+        if (lowerCased.endsWith(".md")) {
+                return lowerCased.slice(0, -3);
+        }
+
+        return lowerCased;
+};
+
 class IgnoreRangeBuilder {
 	private readonly _ignoreRanges: IgnoreRange[] = [];
 	private readonly _cache: CachedMetadata;
 	private _content: string;
 	private _name: string;
+	private readonly _linkCountMap: Map<string, number> = new Map();
 
 	constructor(content: string, cache: CachedMetadata, name: string) {
 		this._content = content;
@@ -19,8 +47,18 @@ class IgnoreRangeBuilder {
 		this._name = name;
 	}
 
-	public build(): IgnoreRange[] {
-		return this._ignoreRanges.sort((a, b) => a.start - b.start);
+	public build(): { ignoreRanges: IgnoreRange[]; linkCountMap: ExistingLinkCountMap } {
+		this._ignoreRanges.sort((a, b) => a.start - b.start);
+
+		const linkCountMap: ExistingLinkCountMap = {};
+		this._linkCountMap.forEach((value, key) => {
+			linkCountMap[key] = value;
+		});
+
+		return {
+			ignoreRanges: this._ignoreRanges,
+			linkCountMap,
+		};
 	}
 
 	// Adds an ignore range from the cache for a specific section type
@@ -43,25 +81,39 @@ class IgnoreRangeBuilder {
 	}
 
 	// adds an ignroe range from the cache for an array of cache items
-	private addCacheItem(cacheItem: CacheItem[]) {
-		(cacheItem ? cacheItem : []).forEach((item) => {
-			const ignoreRange = new IgnoreRange(
-				item.position.start.offset,
-				item.position.end.offset
-			);
-			this._ignoreRanges.push(ignoreRange);
+	private addCacheItem<TItem extends CacheItem>(
+                cacheItem: TItem[] | undefined,
+                onItem?: (item: TItem) => void
+	) {
+                (cacheItem ? cacheItem : []).forEach((item) => {
+                        const ignoreRange = new IgnoreRange(
+                                item.position.start.offset,
+                                item.position.end.offset
+                        );
+                        this._ignoreRanges.push(ignoreRange);
 			this._content =
 				this._content.substring(0, ignoreRange.start) +
 				" ".repeat(ignoreRange.end - ignoreRange.start) +
 				this._content.substring(ignoreRange.end);
-		});
-		return this;
-	}
+                        if (onItem) {
+                                onItem(item);
+                        }
+                });
+                return this;
+        }
 
 	// adds internal links to the ignore ranges
 	// internal links are of the form [[link text]] or [[#link text]]
 	public addInternalLinks(): IgnoreRangeBuilder {
-		return this.addCacheItem(this._cache.links);
+		return this.addCacheItem<LinkCache>(this._cache.links, (item) => {
+			const normalized = normalizeLinkTarget(item.link);
+			if (!normalized) {
+				return;
+			}
+
+			const current = this._linkCountMap.get(normalized) ?? 0;
+			this._linkCountMap.set(normalized, current + 1);
+		});
 	}
 
 	// adds all headings to the ignore ranges
@@ -120,10 +172,14 @@ export default class IgnoreRange extends Range {
 
 	static getIgnoreRangesFromCache(
 		content: string,
-		cache: CachedMetadata,
+		cache: CachedMetadata | null | undefined,
 		name: string
-	): IgnoreRange[] {
-		const ignoreRanges: IgnoreRange[] = new IgnoreRangeBuilder(
+	): { ignoreRanges: IgnoreRange[]; linkCountMap: ExistingLinkCountMap } {
+		if (!cache) {
+			return { ignoreRanges: [], linkCountMap: {} };
+		}
+
+		const builder = new IgnoreRangeBuilder(
 			content,
 			cache,
 			name
@@ -136,9 +192,8 @@ export default class IgnoreRange extends Range {
 			.addMdMetadata()
 			.addHtml()
 			.addMdLinks()
-			.addWebLinks()
-			.build();
+			.addWebLinks();
 
-		return ignoreRanges;
+		return builder.build();
 	}
 }

--- a/src/ts/objects/IgnoreRange.ts
+++ b/src/ts/objects/IgnoreRange.ts
@@ -14,8 +14,6 @@ const normalizeLinkTarget = (link?: string | null): string | null => {
                 return null;
         }
 
-		console.log("Debug:", link); //todo: remove
-
         const trimmed = link.trim();
         if (!trimmed.length) {
                 return null;
@@ -33,7 +31,7 @@ const normalizeLinkTarget = (link?: string | null): string | null => {
                 return lowerCased.slice(0, -3);
         }
 
-        return lowerCased;
+	return lowerCased;
 };
 
 class IgnoreRangeBuilder {

--- a/src/ts/objects/JsNote.ts
+++ b/src/ts/objects/JsNote.ts
@@ -1,5 +1,6 @@
 import { MetadataCache, parseFrontMatterAliases, TFile, Vault } from "obsidian";
 import IgnoreRange from "./IgnoreRange";
+import { ExistingLinkCountMap } from "./IgnoreRange";
 import { Note } from "../../../pkg";
 import { getImpliedNodeFormatForFile } from "typescript";
 
@@ -9,9 +10,11 @@ export default class JsNote extends Note {
 		path: string,
 		content: string,
 		aliases: string[] = [],
-		ignore: IgnoreRange[] = []
+		ignore: IgnoreRange[] = [],
+		existingLinkCounts: ExistingLinkCountMap = {}
 	) {
 		super(title, path, content, aliases, ignore);
+		this.setExistingLinkCounts(existingLinkCounts);
 	}
 
 	static getNumberOfNotes(vault: Vault): number {
@@ -38,13 +41,13 @@ export default class JsNote extends Note {
 		const content = await vault.cachedRead(file);
 		const aliases =
 			parseFrontMatterAliases(cache.getFileCache(file).frontmatter) ?? [];
-		const ignoreRanges =
+		const { ignoreRanges, linkCountMap } = 
 			IgnoreRange.getIgnoreRangesFromCache(
 				content,
 				cache.getFileCache(file),
 				file.name
-			) ?? [];
-		let jsNote: JsNote = new JsNote(name, path, content, aliases, ignoreRanges);
+			);
+		let jsNote: JsNote = new JsNote(name, path, content, aliases, ignoreRanges, linkCountMap);
 		return jsNote;
 	}
 }

--- a/src/ts/webWorkers/WasmWorker.ts
+++ b/src/ts/webWorkers/WasmWorker.ts
@@ -19,6 +19,8 @@ class WasmWorker {
 
 	public findInVault(
 		serializedNotes: Array<string>,
+		maxLinksPerNote: number,
+		countExistingLinks: boolean,
 		callback: Function
 	): Array<string> {
 		const notes: Array<Note> = serializedNotes.map((noteString) =>
@@ -27,7 +29,9 @@ class WasmWorker {
 		const noteMatchingResults: Array<LinkFinderResult> = find_in_vault(
 			this,
 			notes,
-			callback
+			callback,
+			maxLinksPerNote,
+			countExistingLinks
 		);
 		return noteMatchingResults.map((noteMatchingResult) =>
 			noteMatchingResult.toJSON()
@@ -37,6 +41,8 @@ class WasmWorker {
 	public findInNote(
 		serializedNote: string,
 		searializedNotes: Array<string>,
+		maxLinksPerNote: number,
+		countExistingLinks: boolean,
 		callback: Function
 	): Array<string> {
 		const note: Note = Note.fromJSON(serializedNote);
@@ -47,7 +53,9 @@ class WasmWorker {
 			this,
 			note,
 			notes,
-			callback
+			callback,
+			maxLinksPerNote,
+			countExistingLinks
 		);
 		return noteMatchingResults.map((noteMatchingResult) =>
 			noteMatchingResult.toJSON()


### PR DESCRIPTION
Prototype implementation for highly requested feature (AlexW00#52)

## Summary
This PR adds support for limiting how many times a note can be suggested as a link within any given source note, with optional inclusion of existing links in that limit. To support this:
- Existing links are now collected while building ignore ranges, and their normalized targets are carried into each note’s metadata so the matcher can correctly apply per-note limits without performing additional scans.
- Target-note normalization (titles, filenames, aliases, paths) is now applied consistently in both Rust and TypeScript, using equivalent logic in each implementation so matches and existing links resolve to the same canonical form.
- Match discovery short-circuits when a per-note cap is set, stopping the regex scan once the maximum number of suggestions (minus any existing links) has been reached.
- New plugin settings allow users to:
   - enable or disable per-note limits,
   - set the maximum number of suggestions per note (defaults to 3 suggestions per note),
   - control whether existing links count toward that limit.

<img width="913" height="281" alt="image" src="https://github.com/user-attachments/assets/03d2898d-3f1c-45da-917b-3fbc89b7b7a6" />

## Remaining Work
- [ ] Evaluate whether further code optimizations are possible
- [ ] Do more extensive testing (especially on large vaults)
- [ ] Refine settings descriptions for clarity
